### PR TITLE
fix : 가입 조회 관리자 페이지 "가입 대기" 상태의 데이터만 가져오게 변경

### DIFF
--- a/src/main/java/com/example/vvs/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/example/vvs/domain/subscription/controller/SubscriptionController.java
@@ -40,8 +40,8 @@ public class SubscriptionController {
     }
 
     @GetMapping("/subscription/admin")
-    public ResponseEntity<List<SubscriptionResponseDTO>> getAdminSubscriptionPage(@AuthenticationPrincipal MemberDetailsImpl memberDetails) {
-        return subscriptionService.findAllSubscriptionAdminPage(memberDetails.getMember().getId());
+    public ResponseEntity<List<SubscriptionResponseDTO>> getAdminSubscriptionList(@AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        return subscriptionService.findAllSubscriptionAdminList(memberDetails.getMember().getId());
     }
 
     @PatchMapping("/subscription/admin/accept/{subscription-id}")

--- a/src/main/java/com/example/vvs/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/vvs/domain/subscription/repository/SubscriptionRepository.java
@@ -1,9 +1,6 @@
 package com.example.vvs.domain.subscription.repository;
 
-import com.example.vvs.domain.product.entity.Product;
 import com.example.vvs.domain.subscription.entity.Subscription;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,7 +8,7 @@ import java.util.Optional;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
-    List<Subscription> findAllByOrderByApplyDateDesc();
+    List<Subscription> findAllByIsApprovalOrderByApplyDateDesc(String isApproval);
 
     List<Subscription> findAllByMemberIdOrderByApplyDateDesc(Long memberId);
 

--- a/src/main/java/com/example/vvs/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/example/vvs/domain/subscription/service/SubscriptionService.java
@@ -13,8 +13,6 @@ import com.example.vvs.exception.ApiException;
 import com.example.vvs.exception.ErrorHandling;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -113,11 +111,11 @@ public class SubscriptionService {
         return ResponseEntity.ok(subscriptionResponseDTOList);
     }
 
-    public ResponseEntity<List<SubscriptionResponseDTO>> findAllSubscriptionAdminPage(Long memberId) {
+    public ResponseEntity<List<SubscriptionResponseDTO>> findAllSubscriptionAdminList(Long memberId) {
 
         isAdmin(memberId);
 
-        List<Subscription> subscriptionList = subscriptionRepository.findAllByOrderByApplyDateDesc();
+        List<Subscription> subscriptionList = subscriptionRepository.findAllByIsApprovalOrderByApplyDateDesc("가입 대기");
         List<SubscriptionResponseDTO> subscriptionResponseDTOList = new ArrayList<>();
 
 
@@ -139,9 +137,6 @@ public class SubscriptionService {
             subscriptionResponseDTOList.add(subscriptionResponseDTO);
         }
 
-        if (subscriptionResponseDTOList.isEmpty()) {
-            throw new ApiException(EMPTY_SUBSCRIPTION);
-        }
         return ResponseEntity.ok(subscriptionResponseDTOList);
     }
 
@@ -158,10 +153,11 @@ public class SubscriptionService {
 
         return ResponseEntity.ok(MessageDTO.builder()
                 .message("가입 승인이 완료되었습니다")
-                .statusCode(HttpStatus.OK.value())
+                .statusCode(HttpStatus.OK.value()) // 200
                 .build());
     }
 
+    @Transactional
     public ResponseEntity<MessageDTO> updateRejectSubscription(Long id, SubscriptionRequestDTO subscriptionRequestDTO, Long memberId) {
 
         isAdmin(memberId);


### PR DESCRIPTION
## 📕 PR 타입
-[o] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📗 반영 브랜치
- feat/subscription -> dev

## 📘 변경 사항
- 가입 조회 관리자 페이지 "가입 대기" 상태의 데이터만 가져오게 변경

## 📘 테스트 결과
- 확인